### PR TITLE
Convert node versions return by Travis API to Strings

### DIFF
--- a/__tests__/elect-build-leader.js
+++ b/__tests__/elect-build-leader.js
@@ -5,6 +5,8 @@ const electBuildLeader = require('../elect-build-leader')
 test('find highest node version in build matrix', t => {
   t.is(electBuildLeader('1'), 1, 'no matrix')
 
+  t.is(electBuildLeader([3, '2', 1]), 1, 'version as integers')
+
   t.is(electBuildLeader([
     '8',
     '4',

--- a/elect-build-leader.js
+++ b/elect-build-leader.js
@@ -9,6 +9,8 @@ module.exports = versions => {
   const stable = versions.indexOf('node') + 1
   if (stable) return stable
 
+  // Convert to Strings as expected by semver
+  versions = versions.map(version => String(version))
   // otherwise we use the lower bound of all valid semver ranges
   const validRanges = versions.filter(semver.validRange)
   const lowVersionBoundaries = validRanges


### PR DESCRIPTION
Travis API return the Node version as a String or a Number based on the
way it's defined in .travis.yml (node_js: '8' => String / node_js: 8 =>
Number).
`semver` expect a String and consider invalid the versions expressed as
a Number

Fix #347