### PR TITLE
fix(package): depend on fork of travis-ci to get Travis Enterprise support

### DIFF
--- a/lib/get-client.js
+++ b/lib/get-client.js
@@ -1,5 +1,5 @@
 const {promisify} = require('util');
-const Travis = require('travis-ci');
+const Travis = require('@simenb/travis-ci');
 
 /**
  * Authenticate with Travis and return the API client.

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     }
   },
   "dependencies": {
+    "@simenb/travis-ci": "^2.3.1",
     "chalk": "^2.1.0",
     "p-retry": "^1.0.0",
-    "semver": "^5.4.1",
-    "travis-ci": "^2.1.1"
+    "semver": "^5.4.1"
   },
   "devDependencies": {
     "ava": "^0.24.0",


### PR DESCRIPTION
Depending on an unreleased version allows us to support Travis Enterprise

I realise this is probably not acceptable, but I though that maybe 😀 

What I want is this: https://github.com/pwmckenna/node-travis-ci/pull/22, so that https://github.com/semantic-release/condition-travis/pull/101 is unblocked