### PR TITLE
Prioritize the last job defined in case of multiple matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ Run a deployment script only once in the [Travis](https://travis-ci.org/) test m
 
 On Travis builds running multiple jobs (to test with multiple [Node versions](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions) and/or [OSs](https://docs.travis-ci.com/user/multi-os/)), run some code from the `after_success` phase only once, after all other jobs have completed successfully.
 
-Your code will run only on the job with the highest node version (i.e. the build leader).
+Your code will run only on the job identified as the build leader, which is determined as follow, by order of priority:
+- The job with the ID defined in [BUILD_LEADER_ID](#build_leader_id).
+- The job configured with the [latest Node version](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions) (`node_js: node`).
+- The job with the highest node version
+
+**Note**: If multiple jobs match, the one with the highest job ID (which corresponds to the last one defined in `.travis.yml`) will be identified as the build leader.
 
 ## Install
 

--- a/lib/elect-build-leader.js
+++ b/lib/elect-build-leader.js
@@ -19,7 +19,7 @@ module.exports = (versions, logger) => {
 
   // If there is latest stable it's the winner
   // https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions
-  const stable = versions.indexOf('node') + 1;
+  const stable = versions.lastIndexOf('node') + 1;
   if (stable) {
     logger.log(`Elect job ${stable} as build leader as it runs on the latest node stable version.`);
     return stable;
@@ -33,9 +33,9 @@ module.exports = (versions, logger) => {
 
   // Then we find the highest of those
   const highestVersion = semver.sort(Array.from(lowVersionBoundaries)).pop();
-  const highestRange = validRanges[lowVersionBoundaries.indexOf(highestVersion)];
+  const highestRange = validRanges[lowVersionBoundaries.lastIndexOf(highestVersion)];
   // And make its build job the winner
-  const buildLeader = versions.indexOf(highestRange) + 1;
+  const buildLeader = versions.lastIndexOf(highestRange) + 1;
   logger.log(`Elect job ${buildLeader} as build leader as it runs the highest node version (${highestRange}).`);
   return buildLeader;
 };

--- a/test/elect-build-leader.test.js
+++ b/test/elect-build-leader.test.js
@@ -32,8 +32,14 @@ test('Find highest node version with version range', t => {
   t.is(t.context.log.args[1][0], 'Elect job 9 as build leader as it runs the highest node version (>8.4).');
 });
 
-test('Select the first occurence of the highest version', t => {
-  t.is(electBuildLeader(['8.0.0', '8'], t.context.logger), 1);
-  t.is(t.context.log.callCount, 2);
-  t.is(t.context.log.args[1][0], 'Elect job 1 as build leader as it runs the highest node version (8.0.0).');
+test('Select the last occurence of the highest version', t => {
+  t.is(electBuildLeader([7, '8.0.0', 8, '8.x.x', '8.0.0', 7], t.context.logger), 5);
+  t.true(t.context.log.calledTwice);
+  t.is(t.context.log.args[1][0], 'Elect job 5 as build leader as it runs the highest node version (8.0.0).');
+});
+
+test('Select the last occurence of the "latest stable"', t => {
+  t.is(electBuildLeader(['node', '8', '9', 'node', 'node'], t.context.logger), 5);
+  t.true(t.context.log.calledTwice);
+  t.is(t.context.log.args[1][0], 'Elect job 5 as build leader as it runs on the latest node stable version.');
 });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -237,11 +237,11 @@ test.serial('Allow to pass GH_TOKEN as parameter', async t => {
   t.is(t.context.log.args[3][0], 'All jobs are successful for this build!');
 });
 
-test.serial('Choose first occurence of the highest version as leader', async t => {
+test.serial('Choose last occurence of the highest version as leader', async t => {
   const jobId = 456;
   process.env.TRAVIS_BUILD_ID = 123;
   process.env.TRAVIS_JOB_ID = jobId;
-  process.env.TRAVIS_JOB_NUMBER = '1.2';
+  process.env.TRAVIS_JOB_NUMBER = '1.1';
   const jobsFirst = [
     {id: 789, number: '1.1', state: 'started', config: {node_js: 8}},
     {id: jobId, number: '1.2', state: 'started', config: {node_js: 8}},
@@ -254,7 +254,7 @@ test.serial('Choose first occurence of the highest version as leader', async t =
   t.is(await t.context.travisDeployOnce(), null);
   t.true(auth.isDone());
   t.true(travis.isDone());
-  t.is(t.context.log.args[2][0], 'The current job (1.2) is not the build leader.');
+  t.is(t.context.log.args[2][0], 'The current job (1.1) is not the build leader.');
 });
 
 test.serial('Return null if none of the job define a Node version', async t => {


### PR DESCRIPTION
In case of multiple jobs having an equal priority to be the build leader, prefer the last one defined in `.travis.yml`.

This way if users uses build stages, the build leader will be picked among the jobs of the last stage, as long as there is a job running on a Node version equal or higher than all the jobs in other stages. This allow to configure a final stage, and have its job automatically elected as the leader without configuring `BUILD_LEADER_ID`.

For cases in which there is only jobs with distinct Node version the behavior will not change.

For example, with the following config:
```yaml
language: node_js
node_js:
  - 8
  - 6
  - 4
os:
  - linux
  - osx
jobs:
  include:
    - stage: release
      node_js: 8
      os: linux
      after_success: 
        - npm run semantic-release
```
The build leader will be the job with ID 7 (the one from the release stage) as Node 8 is the highest version among all jobs, and the job 7 is defined last.

In regular cases, with the following config:
```yaml
language: node_js
node_js:
  - 8
  - 6
  - 4
```
The build leader will be the one running Node 8 as usual.

That would provide a good solution for semantic-release/condition-travis#96, with minimal modifications, and without changing the current behavior.