### PR TITLE
Refactor test context

### DIFF
--- a/test/elect-build-leader.test.js
+++ b/test/elect-build-leader.test.js
@@ -10,30 +10,30 @@ test.beforeEach(t => {
 
 test('Find highest node version with one version', t => {
   t.is(electBuildLeader('1', t.context.logger), 1, 'no matrix');
-  t.true(t.context.log.calledTwice);
-  t.is(t.context.log.secondCall.args[0], 'Elect job 1 as build leader.');
+  t.is(t.context.log.callCount, 2);
+  t.is(t.context.log.args[1][0], 'Elect job 1 as build leader.');
 });
 
 test('Find highest node version with integer version', t => {
   t.is(electBuildLeader([3, '2', 1], t.context.logger), 1);
-  t.true(t.context.log.calledTwice);
-  t.is(t.context.log.secondCall.args[0], 'Elect job 1 as build leader as it runs the highest node version (3).');
+  t.is(t.context.log.callCount, 2);
+  t.is(t.context.log.args[1][0], 'Elect job 1 as build leader as it runs the highest node version (3).');
 });
 
 test('Select "latest stable" as highest node version', t => {
   t.is(electBuildLeader(['8', '4', '1', 'node', '0.1', 'lts', 'argon', '0.10', '8.4', '4.0.1'], t.context.logger), 4);
-  t.true(t.context.log.calledTwice);
-  t.is(t.context.log.secondCall.args[0], 'Elect job 4 as build leader as it runs on the latest node stable version.');
+  t.is(t.context.log.callCount, 2);
+  t.is(t.context.log.args[1][0], 'Elect job 4 as build leader as it runs on the latest node stable version.');
 });
 
 test('Find highest node version with version range', t => {
   t.is(electBuildLeader(['8', '4', '1', '>=3', '0.1', 'lts', 'argon', '0.10', '>8.4', '4.0.1'], t.context.logger), 9);
-  t.true(t.context.log.calledTwice);
-  t.is(t.context.log.secondCall.args[0], 'Elect job 9 as build leader as it runs the highest node version (>8.4).');
+  t.is(t.context.log.callCount, 2);
+  t.is(t.context.log.args[1][0], 'Elect job 9 as build leader as it runs the highest node version (>8.4).');
 });
 
 test('Select the first occurence of the highest version', t => {
   t.is(electBuildLeader(['8.0.0', '8'], t.context.logger), 1);
-  t.true(t.context.log.calledTwice);
-  t.is(t.context.log.secondCall.args[0], 'Elect job 1 as build leader as it runs the highest node version (8.0.0).');
+  t.is(t.context.log.callCount, 2);
+  t.is(t.context.log.args[1][0], 'Elect job 1 as build leader as it runs the highest node version (8.0.0).');
 });

--- a/test/get-jobs.test.js
+++ b/test/get-jobs.test.js
@@ -3,14 +3,16 @@ import nock from 'nock';
 import getJobs from '../lib/get-jobs';
 import {api} from './helpers/mock-travis';
 
-test.beforeEach(t => {
-  t.context.env = process.env;
-  process.env.TRAVIS_REPO_SLUG = 'test_user/test_repo';
-  process.env.GH_TOKEN = 'GITHUB_TOKEN';
+// Save the current process.env
+const envBackup = Object.assign({}, process.env);
+
+test.beforeEach(() => {
+  process.env = {TRAVIS_REPO_SLUG: 'test_user/test_repo', GH_TOKEN: 'GITHUB_TOKEN'};
 });
 
-test.afterEach.always(t => {
-  process.env = t.context.env;
+test.afterEach.always(() => {
+  // Restore process.env
+  process.env = envBackup;
   nock.cleanAll();
 });
 

--- a/test/get-logger.test.js
+++ b/test/get-logger.test.js
@@ -18,8 +18,8 @@ test('Log with namespace', t => {
   logger.log('test log');
   logger.error('test error');
 
-  t.is(t.context.log.firstCall.args[0], `${chalk.magenta('[Namespace]:')} test log`);
-  t.is(t.context.error.firstCall.args[0], `${chalk.magenta('[Namespace]:')} ${chalk.red('test error')}`);
+  t.is(t.context.log.args[0][0], `${chalk.magenta('[Namespace]:')} test log`);
+  t.is(t.context.error.args[0][0], `${chalk.magenta('[Namespace]:')} ${chalk.red('test error')}`);
 });
 
 test('Log without namespace', t => {
@@ -27,6 +27,6 @@ test('Log without namespace', t => {
   logger.log('test log');
   logger.error('test error');
 
-  t.is(t.context.log.firstCall.args[0], 'test log');
-  t.is(t.context.error.firstCall.args[0], chalk.red('test error'));
+  t.is(t.context.log.args[0][0], 'test log');
+  t.is(t.context.error.args[0][0], chalk.red('test error'));
 });

--- a/test/get-token.test.js
+++ b/test/get-token.test.js
@@ -3,15 +3,16 @@ import nock from 'nock';
 import getToken from '../lib/get-token';
 import {authenticate, unauthorized} from './helpers/mock-travis';
 
-test.beforeEach(t => {
-  t.context.env = process.env;
-  process.env.TRAVIS_REPO_SLUG = 'test_user/test_repo';
-  delete process.env.GH_TOKEN;
-  delete process.env.GITHUB_TOKEN;
+// Save the current process.env
+const envBackup = Object.assign({}, process.env);
+
+test.beforeEach(() => {
+  process.env = {TRAVIS_REPO_SLUG: 'test_user/test_repo'};
 });
 
-test.afterEach.always(t => {
-  process.env = t.context.env;
+test.afterEach.always(() => {
+  // Restore process.env
+  process.env = envBackup;
   nock.cleanAll();
 });
 


### PR DESCRIPTION
Store only objects set in `beforeEach` used in `test`.
Avoid logging useless info on test failure.