### PR TITLE
docs: fix JavaScript example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ const deployOnce = require('travis-deploy-once');
 
 try {
   const result = await deployOnce({travisOpts: {pro: true}, GH_TOKEN: 'xxxxxx', BUILD_LEADER_ID: 1});
+  
+  if (result === true) deployMyThing();
+  if (result === false) console.log('Some job(s) failed');
+  if (result === null) console.log('Did not run as the build leader');
 } catch (err) {
   // something went wrong, and err will tell you what
 }
-
-if (result === true) deployMyThing();
-if (result === false) console.log('Some job(s) failed');
-if (result === null) console.log('Did not run as the build leader');
 ```
 
 ## API


### PR DESCRIPTION
Closes #36

I chose to put the code that uses `result` inside the `try` block because it only really makes sense to use the `result` value when `deployOnce` succeeds.