### PR TITLE
Support iojs and lts for node_js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ On Travis builds running multiple jobs (to test with multiple [Node versions](ht
 Your code will run only on the job identified as the build leader, which is determined as follow, by order of priority:
 - The job with the ID defined in [BUILD_LEADER_ID](#build_leader_id).
 - The job configured with the [latest Node version](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions) (`node_js: node`).
+- The job configured with the [lts Node version](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions) (`node_js: lts/*`).
 - The job with the highest node version
 
 **Note**: If multiple jobs match, the one with the highest job ID (which corresponds to the last one defined in `.travis.yml`) will be identified as the build leader.
@@ -28,7 +29,7 @@ const deployOnce = require('travis-deploy-once');
 
 try {
   const result = await deployOnce({travisOpts: {pro: true}, GH_TOKEN: 'xxxxxx', BUILD_LEADER_ID: 1});
-  
+
   if (result === true) deployMyThing();
   if (result === false) console.log('Some job(s) failed');
   if (result === null) console.log('Did not run as the build leader');

--- a/lib/elect-build-leader.js
+++ b/lib/elect-build-leader.js
@@ -17,12 +17,17 @@ module.exports = (versions, logger) => {
     return 1;
   }
 
-  // If there is latest stable it's the winner
+  // If there is a latest stable/lts node it's the winner
   // https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions
   const stable = versions.lastIndexOf('node') + 1;
   if (stable) {
     logger.log(`Elect job ${stable} as build leader as it runs on the latest node stable version.`);
     return stable;
+  }
+  const lts = versions.lastIndexOf('lts/*') + 1;
+  if (lts) {
+    logger.log(`Elect job ${lts} as build leader as it runs on the node lts version.`);
+    return lts;
   }
 
   // Convert to Strings as it's expected by semver

--- a/test/elect-build-leader.test.js
+++ b/test/elect-build-leader.test.js
@@ -21,9 +21,15 @@ test('Find highest node version with integer version', t => {
 });
 
 test('Select "latest stable" as highest node version', t => {
-  t.is(electBuildLeader(['8', '4', '1', 'node', '0.1', 'lts', 'argon', '0.10', '8.4', '4.0.1'], t.context.logger), 4);
+  t.is(electBuildLeader(['8', '4', '1', 'iojs', 'lts/*', 'node', '0.1', 'argon', '0.10', '8.4'], t.context.logger), 6);
   t.is(t.context.log.callCount, 2);
-  t.is(t.context.log.args[1][0], 'Elect job 4 as build leader as it runs on the latest node stable version.');
+  t.is(t.context.log.args[1][0], 'Elect job 6 as build leader as it runs on the latest node stable version.');
+});
+
+test('Select "latest lts" as highest node version', t => {
+  t.is(electBuildLeader(['8', '4', '1', 'lts/*', '0.1', 'argon', '0.10', '8.4'], t.context.logger), 4);
+  t.is(t.context.log.callCount, 2);
+  t.is(t.context.log.args[1][0], 'Elect job 4 as build leader as it runs on the node lts version.');
 });
 
 test('Find highest node version with version range', t => {


### PR DESCRIPTION
Per [Travis Node.js versions config](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions), the value `node`, `iojs` and `lts/*` are supported for `node_js`.

This PR add supports for `iojs` and `lts/*` in addition of `node`.