### PR TITLE
Allow CLI to run without script argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ Your code will run only on the job identified as the build leader, which is dete
 
 ## CLI
 
-### CLI usage
+```bash
+Usage: travis-deploy-once.js [script]
+```
+
+### CLI usage with script argument
+
+Run the `script` passed in the first argument only if the current job is the build leader and all other jobs are successful and return with the exit code of the script. Return with exit code `0` otherwise.
 
 In `.travis.yml`:
 
@@ -34,6 +40,28 @@ os:
 after_success:
   - npm install -g travis-deploy-once
   - travis-deploy-once "deploy-script --script-arg script-arg-value"
+```
+
+The script `deploy-script` will be called only for the node 8 job running on `linux`. It will be passed the arguments `--script-arg script-arg-value`.
+
+### CLI usage without script argument
+
+Return with exit code `0` if the current job is the build leader and all other jobs are successful. Return with exit code `1` otherwise.
+
+In `.travis.yml`:
+
+```yaml
+language: node_js
+node_js:
+  - 8
+  - 6
+  - 4
+os:
+  - osx
+  - linux
+after_success:
+  - npm install -g travis-deploy-once
+  - travis-deploy-once && deploy-script --script-arg script-arg-value
 ```
 
 The script `deploy-script` will be called only for the node 8 job running on `linux`. It will be passed the arguments `--script-arg script-arg-value`.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -40,6 +40,15 @@ test.serial('Execute the script and return with script exit code if travis-deplo
   t.is(process.exitCode, 100);
 });
 
+test.serial('If no script is set, return with exit code 0 if travis-deploy-once returns "true"', async t => {
+  const travisDeployOnce = stub().resolves(true);
+  const cli = proxyquire('../cli', {'./lib/travis-deploy-once': travisDeployOnce});
+
+  process.argv = ['', ''];
+  await cli();
+  t.is(process.exitCode, 0);
+});
+
 test.serial('Do not execute the script and return with exit code 0 if travis-deploy-once returns "false"', async t => {
   const travisDeployOnce = stub().resolves(false);
   const cli = proxyquire('../cli', {'./lib/travis-deploy-once': travisDeployOnce});
@@ -50,6 +59,15 @@ test.serial('Do not execute the script and return with exit code 0 if travis-dep
   t.falsy(process.exitCode);
 });
 
+test.serial('If no script is set, return with exit code 1 if travis-deploy-once returns "false"', async t => {
+  const travisDeployOnce = stub().resolves(false);
+  const cli = proxyquire('../cli', {'./lib/travis-deploy-once': travisDeployOnce});
+
+  process.argv = ['', ''];
+  await cli();
+  t.is(process.exitCode, 1);
+});
+
 test.serial('Do not execute the script and return with exit code 0 if travis-deploy-once returns "null"', async t => {
   const travisDeployOnce = stub().resolves(null);
   const cli = proxyquire('../cli', {'./lib/travis-deploy-once': travisDeployOnce});
@@ -58,6 +76,15 @@ test.serial('Do not execute the script and return with exit code 0 if travis-dep
   await cli();
   t.notRegex(t.context.logs, /Test script/);
   t.falsy(process.exitCode);
+});
+
+test.serial('If no script is set, return with exit code 1 if travis-deploy-once returns "null"', async t => {
+  const travisDeployOnce = stub().resolves(null);
+  const cli = proxyquire('../cli', {'./lib/travis-deploy-once': travisDeployOnce});
+
+  process.argv = ['', ''];
+  await cli();
+  t.is(process.exitCode, 1);
 });
 
 test.serial('Do not execute the script and return with exit code 1 if travis-deploy-once throws an error', async t => {
@@ -103,19 +130,6 @@ test.serial('Pass options to travis-deploy-once', async t => {
   ]);
   t.regex(t.context.logs, /Test script/);
   t.is(process.exitCode, 0);
-});
-
-test.serial('Return an error if there is no script argument set', async t => {
-  const travisDeployOnce = stub().resolves(true);
-  const cli = proxyquire('../cli', {'./lib/travis-deploy-once': travisDeployOnce});
-
-  process.argv = ['', ''];
-  await cli();
-
-  t.notRegex(t.context.logs, /Test script/);
-  // Check that the CLI display the help message
-  t.regex(t.context.errors, /Run a deployment script only once in the Travis test matrix/);
-  t.is(process.exitCode, 1);
 });
 
 test.serial('Return an error if there is multiple script argument set', async t => {


### PR DESCRIPTION
If no `script` arg is set:
- exit with 0 if on the build leader and other jobs are successful
- exit with one otherwise