### PR TITLE
feat: use last job as leader if no node jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Your code will run only on the job identified as the build leader, which is dete
 - The job configured with the [latest Node version](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions) (`node_js: node`).
 - The job configured with the [lts Node version](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions) (`node_js: lts/*`).
 - The job with the highest node version
+- The job with the highest job number if none of the jobs specify a node version (see [#42](https://github.com/semantic-release/travis-deploy-once/pull/42))
 
 **Note**: If multiple jobs match, the one with the highest job ID (which corresponds to the last one defined in `.travis.yml`) will be identified as the build leader.
 

--- a/lib/elect-build-leader.js
+++ b/lib/elect-build-leader.js
@@ -9,11 +9,13 @@ const semver = require('semver');
  */
 module.exports = (versions, logger) => {
   logger.log(
-    `Elect build leader among builds with Node versions: ${Array.isArray(versions) ? versions.join(', ') : versions}.`
+    `Electing build leader among builds with Node versions: ${
+      Array.isArray(versions) ? versions.join(', ') : versions
+    }.`
   );
   // If there is only one candidate, then it's the winner
   if (!Array.isArray(versions) || versions.length === 1) {
-    logger.log(`Elect job 1 as build leader.`);
+    logger.log(`Electing job (1) as build leader.`);
     return 1;
   }
 
@@ -21,12 +23,12 @@ module.exports = (versions, logger) => {
   // https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions
   const stable = versions.lastIndexOf('node') + 1;
   if (stable) {
-    logger.log(`Elect job ${stable} as build leader as it runs on the latest node stable version.`);
+    logger.log(`Electing job (${stable}) as build leader as it runs on the latest node stable version.`);
     return stable;
   }
   const lts = versions.lastIndexOf('lts/*') + 1;
   if (lts) {
-    logger.log(`Elect job ${lts} as build leader as it runs on the node lts version.`);
+    logger.log(`Electing job (${lts}) as build leader as it runs on the node lts version.`);
     return lts;
   }
 
@@ -41,6 +43,6 @@ module.exports = (versions, logger) => {
   const highestRange = validRanges[lowVersionBoundaries.lastIndexOf(highestVersion)];
   // And make its build job the winner
   const buildLeader = versions.lastIndexOf(highestRange) + 1;
-  logger.log(`Elect job ${buildLeader} as build leader as it runs the highest node version (${highestRange}).`);
+  logger.log(`Electing job (${buildLeader}) as build leader as it runs the highest node version (${highestRange}).`);
   return buildLeader;
 };

--- a/lib/travis-deploy-once.js
+++ b/lib/travis-deploy-once.js
@@ -39,10 +39,8 @@ module.exports = async ({
 
   const versions = jobs.map(job => job.config.node_js);
   if (versions.filter(job => Boolean(job)).length === 0 && !buildLeaderId) {
-    logger.log(
-      'There is no job in this build defining a node version, please set BUILD_LEADER_ID to define the build leader yourself.'
-    );
-    return null;
+    logger.log(`There is no job in this build defining a node version. Electing job (${jobs.length}) as build leader.`);
+    buildLeaderId = jobs.length;
   }
 
   if (!process.env.TRAVIS_JOB_NUMBER.endsWith(`.${buildLeaderId || electBuildLeader(versions, logger)}`)) {

--- a/test/elect-build-leader.test.js
+++ b/test/elect-build-leader.test.js
@@ -11,41 +11,41 @@ test.beforeEach(t => {
 test('Find highest node version with one version', t => {
   t.is(electBuildLeader('1', t.context.logger), 1, 'no matrix');
   t.is(t.context.log.callCount, 2);
-  t.is(t.context.log.args[1][0], 'Elect job 1 as build leader.');
+  t.is(t.context.log.args[1][0], 'Electing job (1) as build leader.');
 });
 
 test('Find highest node version with integer version', t => {
   t.is(electBuildLeader([3, '2', 1], t.context.logger), 1);
   t.is(t.context.log.callCount, 2);
-  t.is(t.context.log.args[1][0], 'Elect job 1 as build leader as it runs the highest node version (3).');
+  t.is(t.context.log.args[1][0], 'Electing job (1) as build leader as it runs the highest node version (3).');
 });
 
 test('Select "latest stable" as highest node version', t => {
   t.is(electBuildLeader(['8', '4', '1', 'iojs', 'lts/*', 'node', '0.1', 'argon', '0.10', '8.4'], t.context.logger), 6);
   t.is(t.context.log.callCount, 2);
-  t.is(t.context.log.args[1][0], 'Elect job 6 as build leader as it runs on the latest node stable version.');
+  t.is(t.context.log.args[1][0], 'Electing job (6) as build leader as it runs on the latest node stable version.');
 });
 
 test('Select "latest lts" as highest node version', t => {
   t.is(electBuildLeader(['8', '4', '1', 'lts/*', '0.1', 'argon', '0.10', '8.4'], t.context.logger), 4);
   t.is(t.context.log.callCount, 2);
-  t.is(t.context.log.args[1][0], 'Elect job 4 as build leader as it runs on the node lts version.');
+  t.is(t.context.log.args[1][0], 'Electing job (4) as build leader as it runs on the node lts version.');
 });
 
 test('Find highest node version with version range', t => {
   t.is(electBuildLeader(['8', '4', '1', '>=3', '0.1', 'lts', 'argon', '0.10', '>8.4', '4.0.1'], t.context.logger), 9);
   t.is(t.context.log.callCount, 2);
-  t.is(t.context.log.args[1][0], 'Elect job 9 as build leader as it runs the highest node version (>8.4).');
+  t.is(t.context.log.args[1][0], 'Electing job (9) as build leader as it runs the highest node version (>8.4).');
 });
 
 test('Select the last occurence of the highest version', t => {
   t.is(electBuildLeader([7, '8.0.0', 8, '8.x.x', '8.0.0', 7], t.context.logger), 5);
   t.true(t.context.log.calledTwice);
-  t.is(t.context.log.args[1][0], 'Elect job 5 as build leader as it runs the highest node version (8.0.0).');
+  t.is(t.context.log.args[1][0], 'Electing job (5) as build leader as it runs the highest node version (8.0.0).');
 });
 
 test('Select the last occurence of the "latest stable"', t => {
   t.is(electBuildLeader(['node', '8', '9', 'node', 'node'], t.context.logger), 5);
   t.true(t.context.log.calledTwice);
-  t.is(t.context.log.args[1][0], 'Elect job 5 as build leader as it runs on the latest node stable version.');
+  t.is(t.context.log.args[1][0], 'Electing job (5) as build leader as it runs on the latest node stable version.');
 });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -259,27 +259,27 @@ test.serial('Choose last occurence of the highest version as leader', async t =>
   t.is(t.context.log.args[2][0], 'The current job (1.1) is not the build leader.');
 });
 
-test.serial('Return null if none of the job define a Node version', async t => {
-  const jobId = 456;
+test.serial('Use the last job as leader if none of the job define a Node version', async t => {
+  const jobId = 789;
   process.env.TRAVIS_BUILD_ID = 123;
   process.env.TRAVIS_JOB_ID = jobId;
-  process.env.TRAVIS_JOB_NUMBER = '1.2';
+  process.env.TRAVIS_JOB_NUMBER = '1.3';
   const jobsFirst = [
-    {id: 111, number: '1.1', state: 'started', config: {java: 8}},
-    {id: jobId, number: '1.2', state: 'started', config: {java: 7}},
-    {id: 789, number: '1.3', state: 'passed', config: {java: 6}},
+    {id: 123, number: '1.1', state: 'passed', config: {java: 6}},
+    {id: 456, number: '1.2', state: 'passed', config: {java: 7}},
+    {id: jobId, number: '1.3', state: 'started', config: {java: 8}},
   ];
   const auth = authenticate();
   const travis = api()
     .get(`/builds/${process.env.TRAVIS_BUILD_ID}`)
     .reply(200, {jobs: jobsFirst});
 
-  t.is(await t.context.travisDeployOnce(), null);
+  t.true(await t.context.travisDeployOnce());
   t.true(auth.isDone());
   t.true(travis.isDone());
   t.is(
     t.context.log.args[0][0],
-    'There is no job in this build defining a node version, please set BUILD_LEADER_ID to define the build leader yourself.'
+    'There is no job in this build defining a node version. Electing job (3) as build leader.'
   );
 });
 


### PR DESCRIPTION
Every Travis images (no matter the [language](https://docs.travis-ci.com/user/languages/) selected) comes with Node and nvm installed.

Currently if there is no job job explicitly defining a Node version we don't select any build leader and the script is never ran anywhere.

That prevent to do something like this:
```yaml
language: go

go:
  - 1.6
  - 1.7

os:
  - osx
  - linux

after_success:
  - nvm install 8
  - npm install -g travis-deploy-once
  - travis-deploy-once "echo test"
```
That config will fails because no job has the `node_js` param. Even when setting `node_js` in `travis.yml` it's not in the config retrieved by the API, as we have the Go version instead.

But it's still possible to run some Javascript  as Node and nvm are always installed no matter the language selected.

With this PR the config above will run the script `echo script` on the the 4th job after the first 3 jobs are completed, without having to set the `BUILD_LEADER_ID`.

Users can still specify the `BUILD_LEADER_ID` to force running on a specific job.
