### PR TITLE
feat: remove restriction of running in `after_success`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Run a deployment script only once in the [Travis](https://travis-ci.org/) test m
 
 **Note**: Travis supports [Build Stages](https://docs.travis-ci.com/user/build-stages) as a beta feature. We recommend to use Build Stages instead of `travis-deploy-once` if possible. It’s a clearer and more flexible way to orchestrate jobs within a build.
 
-On Travis builds running multiple jobs (to test with multiple [Node versions](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions) and/or [OSs](https://docs.travis-ci.com/user/multi-os/)), run some code from the `after_success` phase only once, after all other jobs have completed successfully.
+For Travis builds running multiple jobs (to test with multiple [Node versions](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions) and/or [OSs](https://docs.travis-ci.com/user/multi-os)), `travis-deploy-once` run some code only once, after all other jobs have completed successfully.
+
+`travis-deploy-once` is usually used in the `after_success` step. But if you want your build to break in case the `travis-deploy-once` script returns an error, you can set it in the `script` or `before_script` step (see [Travis Build Lifecycle](https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle)).
 
 Your code will run only on the job identified as the build leader, which is determined as follow, by order of priority:
 - The job with the ID defined in the [-b](#-b---buildleaderid), [--buildLeaderId](#-b---buildleaderid) CLI options or the [buildLeaderId](#buildleaderid) API option or `BUILD_LEADER_ID` environment variable.
@@ -164,7 +166,6 @@ Throws an `Error` if:
 - It doesn't run on Travis.
 - The Github authentication token is missing.
 - The Github authentication token is not authorized with Travis.
-- It doesn't run on after_success step.
 
 #### options
 

--- a/lib/travis-deploy-once.js
+++ b/lib/travis-deploy-once.js
@@ -22,11 +22,6 @@ module.exports = async ({
 } = {}) => {
   const logger = getLogger('Travis Deploy Once');
 
-  if (process.env.TRAVIS_TEST_RESULT === '1') {
-    logger.error('The current job test phase has failed.');
-    return false;
-  }
-
   validate(githubToken);
 
   const buildId = parseInt(process.env.TRAVIS_BUILD_ID, 10);

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -10,11 +10,4 @@
 module.exports = githubToken => {
   if (process.env.TRAVIS !== 'true') throw new Error('Not running on Travis');
   if (!githubToken) throw new Error('GitHub authentication missing');
-  if (
-    typeof process.env.TRAVIS_TEST_RESULT === 'undefined' ||
-    process.env.TRAVIS_TEST_RESULT === false ||
-    process.env.TRAVIS_TEST_RESULT === null
-  ) {
-    throw new Error('Not running in Travis after_success step');
-  }
 };

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -15,7 +15,6 @@ test.beforeEach(t => {
   process.env.TRAVIS_REPO_SLUG = 'test_user/test_repo';
   process.env.GH_TOKEN = 'GITHUB_TOKEN';
   delete process.env.GITHUB_TOKEN;
-  process.env.TRAVIS_TEST_RESULT = '0';
   delete process.env.TRAVIS_BUILD_ID;
   delete process.env.TRAVIS_JOB_ID;
   delete process.env.TRAVIS_JOB_NUMBER;
@@ -137,12 +136,6 @@ test.serial('Return false if the current job is the build leader and another job
   t.is(t.context.log.args[2][0], 'Aborting attempt 1, because of pending job(s): 1.2.');
   t.is(t.context.error.args[0][0], 'Aborting at attempt 2. Job 1.2 failed.');
   t.is(t.context.error.args[1][0], 'At least one job has failed for this build.');
-});
-
-test('Return false if test of current jobs have failed', async t => {
-  process.env.TRAVIS_TEST_RESULT = '1';
-  t.false(await t.context.travisDeployOnce());
-  t.is(t.context.error.args[0][0], 'The current job test phase has failed.');
 });
 
 test.serial('Return null if the current job is not the build leader', async t => {

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -8,7 +8,6 @@ test.beforeEach(() => {
   delete process.env.TRAVIS;
   delete process.env.GH_TOKEN;
   delete process.env.GITHUB_TOKEN;
-  delete process.env.TRAVIS_TEST_RESULT;
   delete process.env.TRAVIS_BUILD_ID;
   delete process.env.TRAVIS_JOB_ID;
   delete process.env.TRAVIS_JOB_NUMBER;
@@ -29,19 +28,7 @@ test('Throw error if GitHub authentication missing', t => {
   t.throws(() => validate(), Error, 'GitHub authentication missing');
 });
 
-test('Throw error if not running in Travis after_success step', t => {
-  process.env.TRAVIS = 'true';
-  t.throws(() => validate('GH_TOKEN'), 'Not running in Travis after_success step');
-  t.throws(() => validate('GH_TOKEN'), 'Not running in Travis after_success step');
-  t.throws(() => validate('GH_TOKEN'), 'Not running in Travis after_success step');
-});
-
 test('Does not throw error if environment is valid', t => {
   process.env.TRAVIS = 'true';
-  process.env.TRAVIS_TEST_RESULT = '1';
-  t.notThrows(() => validate('GH_TOKEN'));
-  process.env.TRAVIS_TEST_RESULT = 0;
-  t.notThrows(() => validate('GH_TOKEN'));
-  process.env.TRAVIS_TEST_RESULT = 1;
   t.notThrows(() => validate('GH_TOKEN'));
 });


### PR DESCRIPTION
There is no much reason for restricting to run scripts only in the `after_sucess`.
`travis-deploy-once` guarantees the script will be run after all the other jobs are successful, but the users should be able to choose if they want to run in `script` or in `after_success` within the job itself.

In addition when used via CLI, `travis-deploy-once` exit with the exit code of the script. Users might want to run scripts that fails the job if the script itself fails.

For example:
```yaml
script:
  - travis-deploy-once "custom-script"
```

And `custom-script` is the script that can returns 0 on 1 depending if it's successful or not.
If the user wants to fail the build when `custom-script` scripts returns 1, then it has to be executed in the Travis `script` phase. If we run it in `after_sucess` the build will not fail even if we exit with 1.

That would allow for example to run `semantic-release` in the `script` phase and fail the build when a problem happens (as `semantic-release` now returns 1 only when a real problem happens).
