### PR TITLE
fix: add `babel-register` file to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "files": [
     "bin",
     "lib",
+    "babel-register",
     "index.js",
     "cli.js"
   ],


### PR DESCRIPTION
Fix #87