### PR TITLE
fix: add `babel-register.js` file to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "files": [
     "bin",
     "lib",
-    "babel-register",
+    "babel-register.js",
     "index.js",
     "cli.js"
   ],


### PR DESCRIPTION
#88 didn't include this file because of a typo.
[Travis logs](https://travis-ci.org/semantic-release/travis-deploy-once/jobs/422385279#L502)
related to #88 #87 