### PR TITLE
fix: fix babel-register config when module is globally installed

### DIFF
--- a/babel-register.js
+++ b/babel-register.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-unassigned-import */
 require('@babel/register')({
-  only: ['lib', 'cli.js', 'node_modules/got', 'node_modules/cacheable-request'],
+  only: [/travis-deploy-once\/(lib|cli.js)/, /node_modules\/(got|cacheable-request)/],
   presets: [['@babel/preset-env', {targets: {node: 'current'}, useBuiltIns: 'entry'}]],
 });
 require('@babel/polyfill');


### PR DESCRIPTION
Fix #95