### PR TITLE
fix: use `require.resolve` to load babel preset

### DIFF
--- a/babel-register.js
+++ b/babel-register.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-unassigned-import */
 require('@babel/register')({
   only: [/travis-deploy-once\/(lib|cli.js)/, /node_modules\/(got|cacheable-request)/],
-  presets: [['@babel/preset-env', {targets: {node: 'current'}, useBuiltIns: 'entry'}]],
+  presets: [[require.resolve('@babel/preset-env'), {targets: {node: 'current'}, useBuiltIns: 'entry'}]],
 });
 require('@babel/polyfill');


### PR DESCRIPTION
Workaround for babel/babel#8777

Fix #98 