### PR TITLE
docs: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ Run a deployment script only once in the [Travis](https://travis-ci.org/) test m
 [![Codecov](https://img.shields.io/codecov/c/github/semantic-release/travis-deploy-once.svg)](https://codecov.io/gh/semantic-release/travis-deploy-once)
 [![Greenkeeper badge](https://badges.greenkeeper.io/semantic-release/travis-deploy-once.svg)](https://greenkeeper.io/)
 
-**Note**: Travis supports [Build Stages](https://docs.travis-ci.com/user/build-stages) as a beta feature. We recommend to use Build Stages instead of `travis-deploy-once` if possible. It’s a clearer and more flexible way to orchestrate jobs within a build.
+## :warning: Deprecation Notice :warning:
+
+**This library is deprecated and will not be maintained. We recommend to use [Build Stages](https://docs.travis-ci.com/user/build-stages) instead. It’s a clearer and more flexible way to orchestrate jobs within a build.**
+
+## Overview
 
 For Travis builds running multiple jobs (to test with multiple [Node versions](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions) and/or [OSs](https://docs.travis-ci.com/user/multi-os)), `travis-deploy-once` run some code only once, after all other jobs have completed successfully.
 


### PR DESCRIPTION
Travis Build Stages are out of beta for a while now so it's time to deprecate `travis-deploy-once`!

We should also deprecate it on npm so user would get a warning.

Finally we should remove it from https://github.com/semantic-release/cli. Not sure if we'll be able to easily have the CLI to generate the Travis build stage config. I think it's acceptable to just display a message to the user that redirect to the [Travis Build Stage recipe](https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/travis-build-stages.md). When we rewrite the CLI we'll implement a better solution.